### PR TITLE
Add meck:expects/1

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -35,6 +35,7 @@
 -export([loop/4]).
 -export([delete/3]).
 -export([delete/4]).
+-export([expects/1]).
 -export([exception/2]).
 -export([passthrough/1]).
 -export([history/1]).
@@ -317,6 +318,17 @@ delete(Mod, Func, Ari, Force) when is_list(Mod) ->
       Ari :: byte().
 delete(Mod, Func, Ari) ->
     delete(Mod, Func, Ari, false).
+
+%% @doc Returns the list of expectations.
+-spec expects(Mods) -> [{Mod, Func, Ari}] when
+      Mods :: Mod | [Mod],
+      Mod :: atom(),
+      Func :: atom(),
+      Ari :: byte().
+expects(Mod) when is_atom(Mod) ->
+    meck_proc:list_expects(Mod);
+expects(Mods) when is_list(Mods) ->
+    [Expect || Mod <- Mods, Expect <- expects(Mod)].
 
 %% @doc Throws an expected exception inside an expect fun.
 %%

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -23,6 +23,7 @@
 -export([start/2]).
 -export([set_expect/2]).
 -export([delete_expect/4]).
+-export([list_expects/1]).
 -export([get_history/1]).
 -export([wait/6]).
 -export([reset/1]).
@@ -123,6 +124,10 @@ set_expect(Mod, Expect) ->
 -spec delete_expect(Mod::atom(), Func::atom(), Ari::byte(), Force::boolean()) -> ok.
 delete_expect(Mod, Func, Ari, Force) ->
     gen_server(call, Mod, {delete_expect, Func, Ari, Force}).
+
+-spec list_expects(Mod::atom()) -> [{Mod::atom(), Func::atom(), Ari::byte}].
+list_expects(Mod) ->
+    gen_server(call, Mod, list_expects).
 
 -spec add_history_exception(
         Mod::atom(), CallerPid::pid(), Func::atom(), Args::[any()],
@@ -251,6 +256,9 @@ handle_call({delete_expect, Func, Ari, Force}, From,
         do_delete_expect(Mod, {Func, Ari}, Expects, ErasePassThrough),
     {noreply, S#state{expects = NewExpects,
                       reload = {CompilerPid, From}}};
+handle_call(list_expects, _From, S = #state{mod = Mod, expects = Expects}) ->
+    Functions = dict:fetch_keys(Expects),
+    {reply, [{Mod, Func, Ari} || {Func, Ari} <- Functions], S};
 handle_call(get_history, _From, S = #state{history = undefined}) ->
     {reply, [], S};
 handle_call(get_history, _From, S) ->

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -73,6 +73,7 @@ meck_test_() ->
                            fun shortcut_opaque_/1,
                            fun shortcut_stacktrace_/1,
                            fun delete_/1,
+                           fun expects_/1,
                            fun called_false_no_args_/1,
                            fun called_true_no_args_/1,
                            fun called_true_two_functions_/1,
@@ -405,6 +406,12 @@ delete_(Mod) ->
     ?assertEqual(ok, meck:delete(Mod, test, 2)),
     ?assertError(undef, Mod:test(a, b)),
     ?assert(meck:validate(Mod)).
+
+expects_(Mod) ->
+    ok = meck:expect(Mod, test, 2, ok),
+    ?assertEqual([{Mod, test, 2}], meck:expects(Mod)),
+    ok = meck:expect(Mod, test2, 0, ok),
+    ?assertEqual([{Mod, test, 2}, {Mod, test2, 0}], lists:sort(meck:expects(Mod))).
 
 called_false_no_args_(Mod) ->
     Args = [],
@@ -1215,6 +1222,14 @@ multi_delete_test() ->
     ?assertEqual(ok, meck:delete(Mods, test, 0)),
     [?assertError(undef, M:test()) || M <- Mods],
     ?assert(meck:validate(Mods)),
+    ok = meck:unload(Mods).
+
+multi_expects_test() ->
+    Mods = [mod1, mod2, mod3],
+    ok = meck:new(Mods, [non_strict]),
+    ok = meck:expect(Mods, test, 0, ok),
+    ?assertEqual([{mod1, test, 0}, {mod2, test, 0}, {mod3, test, 0}],
+                 lists:sort(meck:expects(Mods))),
     ok = meck:unload(Mods).
 
 multi_reset_test() ->


### PR DESCRIPTION
Add a function to retrieve the list of expects for a particular module or list of modules, since we needed a way to determine which functions we had already mocked and which ones we had not.