### PR TITLE
Let meck:expects/1 exclude passthroughs

### DIFF
--- a/src/meck.erl
+++ b/src/meck.erl
@@ -36,6 +36,7 @@
 -export([delete/3]).
 -export([delete/4]).
 -export([expects/1]).
+-export([expects/2]).
 -export([exception/2]).
 -export([passthrough/1]).
 -export([history/1]).
@@ -320,15 +321,31 @@ delete(Mod, Func, Ari) ->
     delete(Mod, Func, Ari, false).
 
 %% @doc Returns the list of expectations.
+%%
+%% Returns the list of MFAs that were replaced by expectations
+%% If `ExcludePassthrough` is on, only expectations that are not
+%% direct passthroughs are returned
+-spec expects(Mods, ExcludePassthrough) -> [{Mod, Func, Ari}] when
+      Mods :: Mod | [Mod],
+      Mod :: atom(),
+      Func :: atom(),
+      Ari :: byte(),
+      ExcludePassthrough :: boolean().
+expects(Mod, ExcludePassthrough) when is_atom(Mod) ->
+    meck_proc:list_expects(Mod, ExcludePassthrough);
+expects(Mods, ExcludePassthrough) when is_list(Mods) ->
+    [Expect || Mod <- Mods, Expect <- expects(Mod, ExcludePassthrough)].
+
+%% @doc Returns the list of expectations.
+%%
+%% Returns the list of MFAs that were replaced by expectations
 -spec expects(Mods) -> [{Mod, Func, Ari}] when
       Mods :: Mod | [Mod],
       Mod :: atom(),
       Func :: atom(),
       Ari :: byte().
-expects(Mod) when is_atom(Mod) ->
-    meck_proc:list_expects(Mod);
-expects(Mods) when is_list(Mods) ->
-    [Expect || Mod <- Mods, Expect <- expects(Mod)].
+expects(Mod) ->
+    expects(Mod, false).
 
 %% @doc Throws an expected exception inside an expect fun.
 %%

--- a/src/meck_expect.erl
+++ b/src/meck_expect.erl
@@ -25,6 +25,7 @@
 -export([new_passthrough/1]).
 -export([new_dummy/2]).
 -export([func_ari/1]).
+-export([is_passthrough/1]).
 -export([fetch_result/2]).
 
 %%%============================================================================
@@ -72,6 +73,12 @@ new_dummy({Func, Ari}, RetSpec) ->
 -spec func_ari(expect()) -> func_ari().
 func_ari({FuncAri, _Clauses}) ->
     FuncAri.
+
+-spec is_passthrough(expect()) -> boolean().
+is_passthrough({_FuncAri, [{_Matcher, RetSpec}]}) ->
+    meck_ret_spec:is_passthrough(RetSpec);
+is_passthrough(_) ->
+    false.
 
 -spec fetch_result(Args::[any()], expect()) ->
         {undefined, unchanged} |

--- a/src/meck_proc.erl
+++ b/src/meck_proc.erl
@@ -23,7 +23,7 @@
 -export([start/2]).
 -export([set_expect/2]).
 -export([delete_expect/4]).
--export([list_expects/1]).
+-export([list_expects/2]).
 -export([get_history/1]).
 -export([wait/6]).
 -export([reset/1]).
@@ -125,9 +125,10 @@ set_expect(Mod, Expect) ->
 delete_expect(Mod, Func, Ari, Force) ->
     gen_server(call, Mod, {delete_expect, Func, Ari, Force}).
 
--spec list_expects(Mod::atom()) -> [{Mod::atom(), Func::atom(), Ari::byte}].
-list_expects(Mod) ->
-    gen_server(call, Mod, list_expects).
+-spec list_expects(Mod::atom(), ExcludePassthrough::boolean()) ->
+    [{Mod::atom(), Func::atom(), Ari::byte}].
+list_expects(Mod, ExcludePassthrough) ->
+    gen_server(call, Mod, {list_expects, ExcludePassthrough}).
 
 -spec add_history_exception(
         Mod::atom(), CallerPid::pid(), Func::atom(), Args::[any()],
@@ -256,9 +257,17 @@ handle_call({delete_expect, Func, Ari, Force}, From,
         do_delete_expect(Mod, {Func, Ari}, Expects, ErasePassThrough),
     {noreply, S#state{expects = NewExpects,
                       reload = {CompilerPid, From}}};
-handle_call(list_expects, _From, S = #state{mod = Mod, expects = Expects}) ->
-    Functions = dict:fetch_keys(Expects),
-    {reply, [{Mod, Func, Ari} || {Func, Ari} <- Functions], S};
+handle_call({list_expects, ExcludePassthrough}, _From, S = #state{mod = Mod, expects = Expects}) ->
+    Result =
+        case ExcludePassthrough of
+            false ->
+                [{Mod, Func, Ari} || {Func, Ari} <- dict:fetch_keys(Expects)];
+            true ->
+                [{Mod, Func, Ari} ||
+                    {{Func, Ari}, Expect} <- dict:to_list(Expects),
+                    not meck_expect:is_passthrough(Expect)]
+        end,
+    {reply, Result, S};
 handle_call(get_history, _From, S = #state{history = undefined}) ->
     {reply, [], S};
 handle_call(get_history, _From, S) ->

--- a/src/meck_ret_spec.erl
+++ b/src/meck_ret_spec.erl
@@ -27,6 +27,7 @@
 -export([loop/1]).
 -export([raise/2]).
 -export([is_meck_exception/1]).
+-export([is_passthrough/1]).
 -export([retrieve_result/1]).
 -export([eval_result/4]).
 
@@ -73,6 +74,9 @@ is_meck_exception({meck_raise, MockedClass, MockedReason}) ->
     {true, MockedClass, MockedReason};
 is_meck_exception(_Reason) ->
     false.
+
+-spec is_passthrough(ret_spec()) -> boolean().
+is_passthrough(RetSpec) -> RetSpec == meck_passthrough.
 
 -spec retrieve_result(RetSpec::ret_spec()) ->
         {result_spec(), NewRetSpec::ret_spec() | unchanged}.

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -1531,7 +1531,8 @@ meck_passthrough_test_() ->
     {foreach, fun setup_passthrough/0, fun teardown/1,
      [{with, [T]} || T <- [
                            fun delete_passthrough_/1,
-                           fun delete_passthrough_force_/1
+                           fun delete_passthrough_force_/1,
+                           fun expects_passthrough_/1
                           ]]}.
 
 setup_passthrough() ->
@@ -1554,6 +1555,13 @@ delete_passthrough_force_(Mod) ->
     ?assertEqual(ok, meck:delete(Mod, c, 2, true)),
     ?assertError(undef, Mod:test(a, b)),
     ?assert(meck:validate(Mod)).
+
+expects_passthrough_(Mod) ->
+    ok = meck:expect(Mod, test, 2, ok),
+    ?assertEqual([{Mod, a, 0}, {Mod, b, 0}, {Mod, c, 2}, {Mod, test, 2}],
+                 lists:sort(meck:expects(Mod, false))),
+    ?assertEqual([{Mod, test, 2}], meck:expects(Mod, true)).
+
 
 %%=============================================================================
 %% Internal Functions

--- a/test/meck_tests.erl
+++ b/test/meck_tests.erl
@@ -408,6 +408,7 @@ delete_(Mod) ->
     ?assert(meck:validate(Mod)).
 
 expects_(Mod) ->
+    ?assertEqual([], meck:expects(Mod)),
     ok = meck:expect(Mod, test, 2, ok),
     ?assertEqual([{Mod, test, 2}], meck:expects(Mod)),
     ok = meck:expect(Mod, test2, 0, ok),


### PR DESCRIPTION
What we actually needed in #1 was to list the functions that were _especifically_ mocked, not those that were just passing through the original module.
Mocks created with `passthrough` will list a passthrough-expectation for each function, with this PR we let `meck:expects/1` exclude those from the returned list.